### PR TITLE
Adjust date selection with search type

### DIFF
--- a/svyPopupFilter/forms/svyDatePopupFilter.js
+++ b/svyPopupFilter/forms/svyDatePopupFilter.js
@@ -1,3 +1,8 @@
+/** @type {String}
+ * @properties={typeid:35,uuid:"DF8798A3-ACD7-450C-BAC3-F9C007485AE3"}
+ */
+var prvOperator = null;
+
 /**
  * Handle changed data, return false if the value should not be accepted. In NGClient you can return also a (i18n) string, instead of false, which will be shown as a tooltip.
  *
@@ -27,16 +32,37 @@ function updateUI() {
 	case OPERATOR.GREATER_THEN:
 	case OPERATOR.GREATER_EQUAL:
 		elements.calendarDateFrom.enabled = true;
+		elements.calendarDateFrom.visible = true;
+		elements.calendarDateFrom.cssPosition.w("calc(100% - 30px)");
 		elements.calendarDateTo.enabled = false;
+		elements.calendarDateTo.visible = false;
+		if(prvOperator == OPERATOR.SMALLER_EQUAL || prvOperator == OPERATOR.SMALLER_THEN)
+			dateFrom = dateTo;		
+		prvOperator = operator;		
 		break;
 	case OPERATOR.SMALLER_THEN:
 	case OPERATOR.SMALLER_EQUAL:
 		elements.calendarDateFrom.enabled = false;
+		elements.calendarDateFrom.visible = false;		
 		elements.calendarDateTo.enabled = true;
+		elements.calendarDateTo.visible = true;
+		elements.calendarDateTo.cssPosition.w("calc(100% - 30px)");
+		if(prvOperator == OPERATOR.GREATER_EQUAL || prvOperator == OPERATOR.GREATER_THEN || prvOperator == OPERATOR.EQUALS || prvOperator == OPERATOR.BETWEEN)
+			dateTo = dateFrom;		
+		prvOperator = operator;		
 		break;
 	case OPERATOR.BETWEEN:
-		elements.calendarDateFrom.enabled = true;
+		elements.calendarDateFrom.enabled = true;	
+		elements.calendarDateFrom.visible = true;	
+		elements.calendarDateFrom.cssPosition.w("calc(50% - 30px)");	
 		elements.calendarDateTo.enabled = true;
+		elements.calendarDateTo.visible = true;	
+		elements.calendarDateTo.cssPosition.w("calc(50% - 30px)");	
+		if(prvOperator == OPERATOR.GREATER_EQUAL || prvOperator == OPERATOR.GREATER_THEN || prvOperator == OPERATOR.EQUALS)
+			dateTo = dateFrom;
+		if(prvOperator == OPERATOR.SMALLER_EQUAL || prvOperator == OPERATOR.SMALLER_THEN)
+			dateFrom = dateTo;		
+		prvOperator = operator;
 		break;
 	default:
 		break;
@@ -55,10 +81,20 @@ function getSelectedFilterValues() {
 	case OPERATOR.EQUALS:
 	case OPERATOR.GREATER_THEN:
 	case OPERATOR.GREATER_EQUAL:
-		return [scopes.svyDateUtils.toStartOfDay(dateFrom)];
+		if (dateFrom){
+			return [scopes.svyDateUtils.toStartOfDay(dateFrom)];
+		}
+		else {
+			return [];
+		}
 	case OPERATOR.SMALLER_THEN:
 	case OPERATOR.SMALLER_EQUAL:
-		return [scopes.svyDateUtils.toEndOfDay(dateTo)];
+	if (dateTo){
+			return [scopes.svyDateUtils.toEndOfDay(dateTo)];
+		}
+		else {
+			return [];
+		}		
 	case OPERATOR.BETWEEN:
 		if (dateFrom && dateTo) {
 			return [scopes.svyDateUtils.toStartOfDay(dateFrom), scopes.svyDateUtils.toEndOfDay(dateTo)];


### PR DESCRIPTION
Adjusted date selection with search type. Only required calendars will appear i.e. only one calendar will appear utilizing full width of popup for 'before than', 'later than', & 'specific dates' options, while both calendars will appear only in case of 'Between' option.

Also, fix has been done for error "Cannot call method setHours()" which occurs if no date is previously  selected and user changes search type but still do not select any date.

[This change Fixes # 9](https://github.com/Servoy/svyPopupFilter/issues/9)